### PR TITLE
fix: repo must be null when helm is in OCI

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,6 +5,7 @@ chart:
   # when helm is a OCI image
   # url: oci://registry-1.docker.io/bitnamicharts/postgresql
   # version: "12.8.3"
+  # repo: null
 
   # when helm is in a registry
   url: https://charts.krateo.io

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,6 +1,8 @@
 chart:
   # when helm is a tgz
   # url: https://github.com/krateoplatformops/krateo-v2-template-fireworksapp/releases/download/0.1.0/fireworks-app-0.1.0.tgz
+  # repo: null
+  # version: null
 
   # when helm is a OCI image
   # url: oci://registry-1.docker.io/bitnamicharts/postgresql


### PR DESCRIPTION
If repo parameter is not set to null when using helm in oci, the following error is reported:

```
Status:
  Conditions:
    Last Transition Time:  2024-10-18T08:16:59Z
    Message:               cannot update object: CompositionDefinition.core.krateo.io "smartroadsapp" is invalid: spec.chart: Invalid value: "object": Repo is required once set
 ```

Setting "repo: null" in values.yaml file used when installing compositiondefinition chart resolve this issue.